### PR TITLE
Speed up parsing notation LLSD

### DIFF
--- a/llsd/base.py
+++ b/llsd/base.py
@@ -147,6 +147,8 @@ class PY3SemanticBytes(BytesType):
 
     def __getitem__(self, item):
         ret = super(PY3SemanticBytes, self).__getitem__(item)
+        # `buffer[n]` should return an integer, but slice syntax like
+        # `buffer[n:n+1]` should still return a `Bytes` object as before.
         if is_integer(item):
             return ord(ret)
         return ret

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -464,15 +464,17 @@ class LLSDBaseParser(object):
                 self._index = read_idx
                 self._error("Trying to read past end of buffer")
 
-            decode_buff[insert_idx] = cc
-            insert_idx += 1
-
-            # We inserted a character, check if we need to expand the buffer.
-            if insert_idx % _DECODE_BUFF_ALLOC_SIZE == 0:
-                # Any additions may now overflow the decoding buffer, make
-                # a new expanded buffer containing the existing contents.
+            try:
+                decode_buff[insert_idx] = cc
+            except IndexError:
+                # Oops, that overflowed the decoding buffer, make a
+                # new expanded buffer containing the existing contents.
                 decode_buff = bytearray(decode_buff)
                 decode_buff.extend(b"\x00" * _DECODE_BUFF_ALLOC_SIZE)
+                decode_buff[insert_idx] = cc
+
+            insert_idx += 1
+
         try:
             # Sync our local read index with the canonical one
             self._index = read_idx

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -141,6 +141,17 @@ else:
             return fmt
 
 
+class PY3SemanticBytes(BytesType):
+    """Wrapper to make `buffer[n]` return an integer like in Py3"""
+    __slots__ = []
+
+    def __getitem__(self, item):
+        ret = super(PY3SemanticBytes, self).__getitem__(item)
+        if is_integer(item):
+            return ord(ret)
+        return ret
+
+
 def is_integer(o):
     """ portable test if an object is like an int """
     return isinstance(o, IntTypes)

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -440,10 +440,17 @@ class LLSDBaseParser(object):
                     if cc == _X_ORD:
                         # It's a hex escape. char is the value of the two
                         # following hex nybbles
-                        cc = int(chr(buff[read_idx]), 16) << 4
-                        read_idx += 1
-                        cc |= int(chr(buff[read_idx]), 16)
-                        read_idx += 1
+                        try:
+                            cc = int(chr(buff[read_idx]), 16) << 4
+                            read_idx += 1
+                            cc |= int(chr(buff[read_idx]), 16)
+                            read_idx += 1
+                        except ValueError as e:
+                            # One of the hex characters was likely invalid.
+                            # Wrap the ValueError so that we can provide a
+                            # byte offset in the error.
+                            self._index = read_idx
+                            self._error(str(e))
                     else:
                         # escape char preceding anything other than the chars
                         # in _escaped just results in that same char without

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -4,7 +4,7 @@ import struct
 import uuid
 
 from llsd.base import (_LLSD, LLSDBaseParser, LLSDSerializationError, _str_to_bytes, binary, is_integer, is_string,
-                       starts_with, uri)
+                       starts_with, uri, PY2, is_bytes, PY3SemanticBytes)
 
 
 class LLSDBinaryParser(LLSDBaseParser):
@@ -63,6 +63,10 @@ class LLSDBinaryParser(LLSDBaseParser):
         :param ignore_binary: parser throws away data in llsd binary nodes.
         :returns: returns a python object.
         """
+        if PY2 and is_bytes(buffer):
+            # We need to wrap this in a helper class so that individual element
+            # access works the same as in PY3
+            buffer = PY3SemanticBytes(buffer)
         self._buffer = buffer
         self._index = 0
         self._keep_binary = not ignore_binary

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -13,6 +13,8 @@ class LLSDBinaryParser(LLSDBaseParser):
 
     See http://wiki.secondlife.com/wiki/LLSD#Binary_Serialization
     """
+    __slots__ = ['_dispatch', '_keep_binary']
+
     def __init__(self):
         super(LLSDBinaryParser, self).__init__()
         # One way of dispatching based on the next character we see would be a

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -4,7 +4,7 @@ import re
 import uuid
 
 from llsd.base import (_LLSD, B, LLSDBaseFormatter, LLSDBaseParser, LLSDParseError, LLSDSerializationError, UnicodeType,
-                       _format_datestr, _parse_datestr, _str_to_bytes, binary, uri)
+                       _format_datestr, _parse_datestr, _str_to_bytes, binary, uri, PY2, is_bytes, PY3SemanticBytes)
 
 _int_regex = re.compile(br"[-+]?\d+")
 _real_regex = re.compile(br"[-+]?(?:(\d+(\.\d*)?|\d*\.\d+)([eE][-+]?\d+)?)|[-+]?inf|[-+]?nan")
@@ -85,6 +85,11 @@ class LLSDNotationParser(LLSDBaseParser):
         """
         if buffer == b"":
             return False
+
+        if PY2 and is_bytes(buffer):
+            # We need to wrap this in a helper class so that individual element
+            # access works the same as in PY3
+            buffer = PY3SemanticBytes(buffer)
 
         self._buffer = buffer
         self._index = 0

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -328,6 +328,8 @@ class LLSDNotationFormatter(LLSDBaseFormatter):
 
     See http://wiki.secondlife.com/wiki/LLSD#Notation_Serialization
     """
+    __slots__ = []
+
     def LLSD(self, v):
         return self._generate(v.thing)
     def UNDEF(self, v):

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -36,6 +36,7 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
     module level format_xml is the most convenient interface to this
     functionality.
     """
+    __slots__ = []
 
     def _elt(self, name, contents=None):
         "Serialize a single element."

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -507,6 +507,12 @@ class LLSDNotationUnitTest(unittest.TestCase):
         except llsd.LLSDParseError:
             pass
 
+    def testParseNotationUnterminatedString(self):
+        """
+        Test with an unterminated delimited string
+        """
+        self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'foo")
+
 
 class LLSDBinaryUnitTest(unittest.TestCase):
     """

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -513,11 +513,15 @@ class LLSDNotationUnitTest(unittest.TestCase):
         """
         self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'foo")
 
-    def testParseNotationTruncatedHex(self):
+    def testParseNotationHexEscapeNoChars(self):
+        self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\x")
+
+    def testParseNotationHalfTruncatedHex(self):
         self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\xf")
 
     def testParseNotationInvalidHex(self):
         self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\xzz'")
+
 
 class LLSDBinaryUnitTest(unittest.TestCase):
     """

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -513,6 +513,11 @@ class LLSDNotationUnitTest(unittest.TestCase):
         """
         self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'foo")
 
+    def testParseNotationTruncatedHex(self):
+        self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\xf")
+
+    def testParseNotationInvalidHex(self):
+        self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\xzz'")
 
 class LLSDBinaryUnitTest(unittest.TestCase):
     """


### PR DESCRIPTION
Thanks for splitting out this code!

As part of working with LEAP API, I need to parse very large notation LLSD payloads containing a large number of strings. The parsing of those payloads is currently heavily bottle-necked by the code handling delimited strings.

For example, invoking the `LLWindowListener::getPaths()` method over LEAP returns a 5.5mb blob of LLSD (assuming logged in with a relatively bare inventory,) and that payload takes 2.5s to parse with `llsd.parse()`. Since latency is important when dealing with LEAP, I looked at how [`ujson` implemented their delimited string handling](https://github.com/ultrajson/ultrajson/blob/d84c832060a1874085d04c6552977fa804a105b8/lib/ultrajsondec.c#L360-L585) to see how `llsd`'s string handling logic could be improved.

I ended up:

* Removing use of `self._getc()` and reading from `self._buffer` directly, this was the most significant improvement. Since we need to read a byte at a time, getting single-byte byte strings is inefficient. The function not using a potentially overridden `self._getc()` shouldn't be an issue, since [`LLSDBinaryParser` has done manual manipulation of `self._index`](https://github.com/secondlife/python-llsd/blob/22fbfbd37cede755facddc8ef966fd2701ba4567/llsd/serde_binary.py#L116) for a long time now. Basically, `self._getc()` must operate on `self._buffer` and `self._index` for the parsers to work correctly, so not using the abstraction in this particular case shouldn't break any existing uses
* Removing `self` references inside the loop to avoid the attribute lookup cost
* Slightly reordering the logic to do fewer comparisons per iteration in the common case of non-special characters
* Using a pre-allocated decode buffer for all string parses, only using an expanded, dynamically-allocated buffer when the string's size exceeds that of the shared buffer. This avoids costly dynamic allocs associated with doing `my_str.append(char)` in a hot loop.
* Precalculating as much as possible to avoid function calls in the hot loop (the value of `ord('\\')`, etc.)

Given a script like

```python
import llsd
with open("large_getPaths_resp.llsd", "rb") as f:
        llsd.parse(f.read())
```

the script now takes 0.7~s to complete rather than the 2.5s it previously took.

Much better improvements are also possible, but they would either change how invalid escapes like `\p` are handled, or would require native code.