### PR TITLE
ci: replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Determine pyenv
         id: pyenv
-        run: echo "::set-output name=value::py$(echo $PYTHON | tr -d '.')"
+        run: echo "value=py$(echo $PYTHON | tr -d '.')" >> $GITHUB_OUTPUT
 
       - name: Run tests
         env:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/