### PR TITLE
SL-18330: Support parsing direct from stream; improve C++ compatibility.

### DIFF
--- a/llsd/__init__.py
+++ b/llsd/__init__.py
@@ -9,38 +9,51 @@ http://wiki.secondlife.com/wiki/LLSD
 """
 from llsd.base import (_LLSD, BINARY_MIME_TYPE, NOTATION_MIME_TYPE, XML_MIME_TYPE, LLSDParseError,
                        LLSDSerializationError, LongType, UnicodeType, binary, starts_with, undef, uri)
-from llsd.serde_binary import LLSDBinaryParser, format_binary, parse_binary
-from llsd.serde_notation import LLSDNotationFormatter, LLSDNotationParser, format_notation, parse_notation
-from llsd.serde_xml import LLSDXMLFormatter, LLSDXMLPrettyFormatter, format_pretty_xml, format_xml, parse_xml
+from llsd.serde_binary import LLSDBinaryParser, format_binary, parse_binary, match_binary_hdr, parse_binary_noh
+from llsd.serde_notation import LLSDNotationFormatter, LLSDNotationParser, format_notation, parse_notation, match_notation_hdr, parse_notation_noh
+from llsd.serde_xml import LLSDXMLFormatter, LLSDXMLPrettyFormatter, format_pretty_xml, format_xml, parse_xml, match_xml_hdr, parse_xml_noh
 
 
 def parse(something, mime_type = None):
     """
     This is the basic public interface for parsing llsd.
 
-    :param something: The data to parse. This is expected to be bytes, not strings
+    :param something: The data to parse. This is expected to be bytes, not
+           strings, or a byte stream.
     :param mime_type: The mime_type of the data if it is known.
     :returns: Returns a python object.
 
     Python 3 Note: when reading LLSD from a file, use open()'s 'rb' mode explicitly
     """
-    if mime_type in (XML_MIME_TYPE, 'application/llsd'):
-        return parse_xml(something)
-    elif mime_type == BINARY_MIME_TYPE:
-        return parse_binary(something)
-    elif mime_type == NOTATION_MIME_TYPE:
-        return parse_notation(something)
-    #elif content_type == 'application/json':
-    #    return parse_notation(something)
     try:
-        something = something.lstrip()   #remove any pre-trailing whitespace
-        if starts_with(b'<?llsd/binary?>', something):
-            return parse_binary(something)
-        # This should be better.
-        elif starts_with(b'<', something):
-            return parse_xml(something)
+        if mime_type:
+            # explicit mime_type -- 'something' may or may not also have a header
+            for mime_types, parser in (
+                    ({XML_MIME_TYPE, 'application/llsd'}, parse_xml),
+                    ({BINARY_MIME_TYPE},                  parse_binary),
+                    ({NOTATION_MIME_TYPE},                parse_notation),
+##                  ({'application/json'},                parse_notation),
+                    ):
+                if mime_type.lower() in mime_types:
+                    return parser(something)
+
+        # no recognized mime type, look for header
+        for matcher, parser in (
+                (match_binary_hdr,   parse_binary_noh),
+                (match_notation_hdr, parse_notation_noh),
+                (match_xml_hdr,      parse_xml_noh),
+                ):
+            remainder = matcher(something)
+            if remainder is not None:
+                # we already saw the header, don't check again
+                return parser(remainder)
+
+        # no recognized header -- does content resemble XML?
+        if starts_with(b'<', something):
+            return parse_xml_noh(something)
         else:
-            return parse_notation(something)
+            return parse_notation_noh(something)
+
     except KeyError as e:
         raise LLSDParseError('LLSD could not be parsed: %s' % (e,))
     except TypeError as e:

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -79,12 +79,6 @@ try:
 except NameError:
     UnicodeType = str
 
-# can't just check for NameError: 'bytes' is defined in both Python 2 and 3
-if PY2:
-    BytesType = str
-else:
-    BytesType = bytes
-
 try:
     b'%s' % (b'yes',)
 except TypeError:
@@ -142,7 +136,7 @@ else:
             return fmt
 
 
-class PY3SemanticBytes(BytesType):
+class PY3SemanticBytes(bytes):
     """Wrapper to make `buffer[n]` return an integer like in Py3"""
     __slots__ = []
 
@@ -172,7 +166,7 @@ def is_string(o):
 
 def is_bytes(o):
     """ portable check if an object is an immutable byte array """
-    return isinstance(o, BytesType)
+    return isinstance(o, bytes)
 
 
 #date: d"YYYY-MM-DDTHH:MM:SS.FFFFFFZ"

--- a/llsd/fastest_elementtree.py
+++ b/llsd/fastest_elementtree.py
@@ -17,32 +17,49 @@ Use ElementTreeError as the exception type for catching parsing
 errors.
 """
 
+# TODO: drop version sensitivity, replacing entire module with:
+#from xml.etree.ElementTree import *
+#ElementTreeError = ParseError
+
 ##
 # Using cElementTree might cause some unforeseen problems, so here's a
 # convenient off switch during development and testing.
 _use_celementree = True
 
+# xml.etree.cElementTree has been deprecated since Python 3.3.
+# For speed in the common case of Python 3.3+, don't even start with that.
+import sys
+if sys.version_info[:2] >= (3, 3):
+    _use_celementree = False
+
 try:
+    # nat wishes for a nicer way to skip even attempting cElementTree than by
+    # explicitly raising ImportError. The problem is that we want to be able
+    # to 'import *' into the global namespace, which forbids packaging any of
+    # this logic in a function. Nor can we 'return' early from a module. It
+    # seems the only way to avoid the explicit exception would be to restate
+    # the entirety of each 'except ImportError' clause, which would be worse.
     if not _use_celementree:
         raise ImportError()
-    # Python 2.3 and 2.4.
-    from cElementTree import *
+    # Python 2.5 and above.
+    from xml.etree.cElementTree import *
     ElementTreeError = SyntaxError
 except ImportError:
     try:
-        if not _use_celementree:
-            raise ImportError()
-        # Python 2.5 and above.
-        from xml.etree.cElementTree import *
-        ElementTreeError = SyntaxError
-    except ImportError:
-        # Pure Python code.
+        # Python 2.5 and above: the common case.
+        from xml.etree.ElementTree import *
         try:
-            # Python 2.3 and 2.4.
-            from elementtree.ElementTree import *
+            # Python 3
+            ElementTreeError = ParseError
+        except NameError:
+            # The older Python ElementTree module uses Expat for parsing.
+            from xml.parsers.expat import ExpatError as ElementTreeError
+    except ImportError:
+        # Python 2.3 and 2.4.
+        try:
+            if not _use_celementree:
+                raise ImportError()
+            from cElementTree import *
+            ElementTreeError = SyntaxError
         except ImportError:
-            # Python 2.5 and above.
-            from xml.etree.ElementTree import *
-
-        # The pure Python ElementTree module uses Expat for parsing.
-        from xml.parsers.expat import ExpatError as ElementTreeError
+            from elementtree.ElementTree import *

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -67,8 +67,7 @@ class LLSDBinaryParser(LLSDBaseParser):
             # We need to wrap this in a helper class so that individual element
             # access works the same as in PY3
             buffer = PY3SemanticBytes(buffer)
-        self._buffer = buffer
-        self._index = 0
+        self._reset(buffer)
         self._keep_binary = not ignore_binary
         try:
             return self._parse()
@@ -119,7 +118,7 @@ class LLSDBinaryParser(LLSDBaseParser):
             cc = self._peek()
         if cc != b']':
             self._error("invalid array close token")
-        self._index += 1
+        self._getc()
         return rv
 
     def _parse_string(self):

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -119,10 +119,10 @@ class LLSDNotationParser(LLSDBaseParser):
         # this method as individual operations on _util, peek ahead by a
         # reasonable amount and directly use re. full=False means we're
         # willing to accept a result buffer shorter than our lookahead.
-        # You would think we could parse int, real, true or false with fewer
+        # You would think we could parse int, real, True or False with fewer
         # bytes than this, but fuzz testing produces some real humdinger int
         # values.
-        peek = self._peek(40, full=False)
+        peek = self._peek(80, full=False)
         match = regex.match(peek)
         if not match:
             self._error("Invalid %s token" % desc)

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -3,8 +3,8 @@ import re
 import types
 
 from llsd.base import (_LLSD, ALL_CHARS, B, LLSDBaseFormatter, LLSDParseError, LLSDSerializationError, UnicodeType,
-                       _format_datestr, _str_to_bytes, _to_python, is_unicode)
-from llsd.fastest_elementtree import ElementTreeError, fromstring
+                       _format_datestr, _str_to_bytes, _to_python, is_unicode, matchseq)
+from llsd.fastest_elementtree import ElementTreeError, fromstring, parse as _parse
 
 INVALID_XML_BYTES = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c'\
                     b'\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18'\
@@ -226,12 +226,6 @@ def format_pretty_xml(something):
     return LLSDXMLPrettyFormatter().format(something)
 
 
-declaration_regex = re.compile(br'^\s*(?:<\?[\x09\x0A\x0D\x20-\x7e]+\?>)|(?:<llsd>)')
-def validate_xml_declaration(something):
-    if not declaration_regex.match(something):
-        raise LLSDParseError("Invalid XML Declaration")
-
-
 def parse_xml(something):
     """
     This is the basic public interface for parsing llsd+xml.
@@ -239,12 +233,43 @@ def parse_xml(something):
     :param something: The data to parse.
     :returns: Returns a python object.
     """
+    # Try to match header, and if matched, skip past it.
+    remainder = match_xml_hdr(something)
+    # If we matched the header, then parse whatever follows, else parse the
+    # original bytes object or stream.
+    return parse_xml_noh(remainder if remainder is not None else something)
+
+
+def match_xml_hdr(something):
+    return matchseq(something, b'<? llsd/xml ?>')
+
+
+def parse_xml_noh(something):
+    """
+    Parse llsd+xml known to be without an <? LLSD/XML ?> header. May still
+    have a normal XML declaration, e.g. <?xml version="1.0" ?>.
+
+    :param something: The data to parse in an indexable sequence.
+    :returns: Returns a python object.
+    """
+    # Python 3.9's xml.etree.ElementTree.fromstring() does not like whitespace
+    # before XML declaration. Since we explicitly test support for that case,
+    # skip initial whitespace.
+    something = matchseq(something, b'')
     try:
-        # validate xml declaration manually until http://bugs.python.org/issue7138 is fixed
-        validate_xml_declaration(something)
-        return _to_python(fromstring(something)[0])
+        if isinstance(something, bytes):
+            element = fromstring(something)
+        else:
+            # file stream
+            element = _parse(something)
     except ElementTreeError as err:
         raise LLSDParseError(*err.args)
+
+    # We expect that the outer-level XML element is <llsd>...</llsd>.
+    if element.tag != 'llsd':
+        raise LLSDParseError("Invalid XML Declaration")
+    # Extract its contents.
+    return _to_python(element[0])
 
 
 _g_xml_formatter = None

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -261,7 +261,7 @@ def parse_xml_noh(something):
             element = fromstring(something)
         else:
             # file stream
-            element = _parse(something)
+            element = _parse(something).getroot()
     except ElementTreeError as err:
         raise LLSDParseError(*err.args)
 

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -3,14 +3,15 @@
 from __future__ import print_function
 
 import base64
+from datetime import date, datetime
+import io
+from itertools import islice
 import pprint
 import re
 import struct
 import time
 import unittest
 import uuid
-from datetime import date, datetime
-from itertools import islice
 
 import pytest
 
@@ -60,7 +61,7 @@ class LLSDNotationUnitTest(unittest.TestCase):
         :Parameters:
         - 'the_string': string to remove the whitespaces.
         """
-        return re.sub(b'\s', b'', the_string)
+        return re.sub(rb'\s', b'', the_string)
 
     def assertNotationRoundtrip(self, py_in, str_in, is_alternate_notation=False):
         """
@@ -69,8 +70,12 @@ class LLSDNotationUnitTest(unittest.TestCase):
         """
         # use parse to check here
         py_out = self.llsd.parse(str_in)
+        py_out2 = self.llsd.parse(io.BytesIO(str_in))
+        self.assertEqual(py_out2, py_out)
         str_out = self.llsd.as_notation(py_in)
         py_roundtrip = self.llsd.parse(str_out)
+        py_roundtrip2 = self.llsd.parse(io.BytesIO(str_out))
+        self.assertEqual(py_roundtrip2, py_roundtrip)
         str_roundtrip = self.llsd.as_notation(py_out)
         # compare user-passed Python data with parsed user-passed string
         self.assertEqual(py_in, py_out)
@@ -325,7 +330,7 @@ class LLSDNotationUnitTest(unittest.TestCase):
         notation3 = b'b16' + b'"' + base64.b16encode(string_data1).strip() + b'"'
         notation4 = b'b16' + b'"' + base64.b16encode(string_data2).strip() + b'"'
         notation5 = b'b85' + b'"<~EHPu*CER),Dg-(AAoDo;+T~>"'
-        notation6 = b'b85' + b'"<~4E*J.<+0QR+EMI<AKYi.Eb-@U@3B6(AS+(L06_,GBeNFs@3Qh9Bln0&4X*j:@3RmWARR\S@6Peb+s:u@AKX]UEarc*87?OM+ELt*A0>u4+@0gX@q@26G%G]>+D"u%DImm2Cj@Wq05s)~>"'
+        notation6 = b'b85' +rb'"<~4E*J.<+0QR+EMI<AKYi.Eb-@U@3B6(AS+(L06_,GBeNFs@3Qh9Bln0&4X*j:@3RmWARR\S@6Peb+s:u@AKX]UEarc*87?OM+ELt*A0>u4+@0gX@q@26G%G]>+D"u%DImm2Cj@Wq05s)~>"'
 
         self.assertNotationRoundtrip(python_binary1, notation1, True)
         self.assertNotationRoundtrip(python_binary2, notation2, True)
@@ -546,7 +551,10 @@ class LLSDBinaryUnitTest(unittest.TestCase):
         return the object.
         """
         binary = self.llsd.as_binary(something)
-        return self.llsd.parse(binary)
+        frombytes = self.llsd.parse(binary)
+        fromstream = self.llsd.parse(io.BytesIO(binary))
+        self.assertEqual(fromstream, frombytes)
+        return frombytes
 
     def testMap(self):
         """
@@ -981,6 +989,8 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
 
         # use parse to check
         parsed_py = self.llsd.parse(xml)
+        parsed_stream = self.llsd.parse(io.BytesIO(xml))
+        self.assertEqual(parsed_stream, parsed_py)
         formatted_xml = self.llsd.as_xml(py)
         self.assertEqual(parsed_py, py)
         self.assertEqual(py, self.llsd.parse(formatted_xml))
@@ -1557,7 +1567,7 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
         Utility method to remove all the whitespace characters from
         the given string.
         """
-        return re.sub(b'\s', b'', the_string)
+        return re.sub(rb'\s', b'', the_string)
 
     def test_segfault(self):
         for i, badstring in enumerate([

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -61,7 +61,7 @@ class LLSDNotationUnitTest(unittest.TestCase):
         :Parameters:
         - 'the_string': string to remove the whitespaces.
         """
-        return re.sub(rb'\s', b'', the_string)
+        return re.sub(br'\s', b'', the_string)
 
     def assertNotationRoundtrip(self, py_in, str_in, is_alternate_notation=False):
         """
@@ -330,7 +330,7 @@ class LLSDNotationUnitTest(unittest.TestCase):
         notation3 = b'b16' + b'"' + base64.b16encode(string_data1).strip() + b'"'
         notation4 = b'b16' + b'"' + base64.b16encode(string_data2).strip() + b'"'
         notation5 = b'b85' + b'"<~EHPu*CER),Dg-(AAoDo;+T~>"'
-        notation6 = b'b85' +rb'"<~4E*J.<+0QR+EMI<AKYi.Eb-@U@3B6(AS+(L06_,GBeNFs@3Qh9Bln0&4X*j:@3RmWARR\S@6Peb+s:u@AKX]UEarc*87?OM+ELt*A0>u4+@0gX@q@26G%G]>+D"u%DImm2Cj@Wq05s)~>"'
+        notation6 = b'b85' +br'"<~4E*J.<+0QR+EMI<AKYi.Eb-@U@3B6(AS+(L06_,GBeNFs@3Qh9Bln0&4X*j:@3RmWARR\S@6Peb+s:u@AKX]UEarc*87?OM+ELt*A0>u4+@0gX@q@26G%G]>+D"u%DImm2Cj@Wq05s)~>"'
 
         self.assertNotationRoundtrip(python_binary1, notation1, True)
         self.assertNotationRoundtrip(python_binary2, notation2, True)
@@ -1567,7 +1567,7 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
         Utility method to remove all the whitespace characters from
         the given string.
         """
-        return re.sub(rb'\s', b'', the_string)
+        return re.sub(br'\s', b'', the_string)
 
     def test_segfault(self):
         for i, badstring in enumerate([


### PR DESCRIPTION
The major feature introduced by this PR is that `llsd.parse()` can now accept a seekable binary stream instead of requiring the caller to read the stream (e.g. a file) into memory before parsing.

It also improves recognition of MIME-type headers produced by the C++ LLSD library embedded in the Second Life viewer.