### PR TITLE
SL-18330: Refactor notation parsing to manage a lookahead char.

### DIFF
--- a/llsd/base.py
+++ b/llsd/base.py
@@ -450,11 +450,17 @@ class LLSDBaseParser(object):
             c = self._stream.read(1)
         return c
 
-    def _getc(self, num=1):
+    def _getc(self, num=1, full=True):
         got = self._stream.read(num)
-        if len(got) < num:
+        if full and len(got) < num:
             self._error("Trying to read past end of stream")
         return got
+
+    def _putback(self, num=1):
+        # if either of these tests fail, it's not a user error, it's a coding error
+        assert num > 0
+        assert self._stream.tell() >= num
+        self._stream.seek(-num, io.SEEK_CUR)
 
     def _peek(self, num=1, full=True):
         # full=True means error if we can't peek ahead num bytes

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -498,7 +498,7 @@ class LLSDBaseParser(object):
         # 'offset' is relative to current pos
         self._stream.seek(offset, io.SEEK_CUR)
         raise LLSDParseError("%s at byte %d: %r" %
-                             (message, oldpos+offset, self._peek(1, full=False)))
+                             (message, oldpos+offset, self._getc(1, full=False)))
 
     # map char following escape char to corresponding character
     _escaped = {

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -63,15 +63,16 @@ class LLSDBinaryParser(LLSDBaseParser):
         for c, func in _dispatch_dict.items():
             self._dispatch[ord(c)] = func
 
-    def parse(self, buffer, ignore_binary = False):
+    def parse(self, something, ignore_binary = False):
         """
         This is the basic public interface for parsing.
 
-        :param buffer: the binary data to parse in an indexable sequence.
+        :param something: serialized LLSD to parse: a bytes object, a binary
+                          stream or an LLSDBaseParser subclass.
         :param ignore_binary: parser throws away data in llsd binary nodes.
         :returns: returns a python object.
         """
-        self._reset(buffer)
+        self._reset(something)
         self._keep_binary = not ignore_binary
         try:
             return self._parse()

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -7,6 +7,14 @@ from llsd.base import (_LLSD, LLSDBaseParser, LLSDSerializationError, BINARY_HEA
                        _str_to_bytes, binary, is_integer, is_string, uri)
 
 
+try:
+    # Python 2
+    xrange
+except NameError:
+    # Python 3
+    xrange = range
+
+
 class LLSDBinaryParser(LLSDBaseParser):
     """
     Parse application/llsd+binary to a python object.
@@ -106,15 +114,10 @@ class LLSDBinaryParser(LLSDBaseParser):
         "Parse a single llsd array"
         rv = []
         size = struct.unpack("!i", self._getc(4))[0]
-        count = 0
-        cc = self._peek()
-        while (cc != b']') and (count < size):
+        for count in xrange(size):
             rv.append(self._parse())
-            count += 1
-            cc = self._peek()
-        if cc != b']':
+        if self._getc() != b']':
             self._error("invalid array close token")
-        self._getc()
         return rv
 
     def _parse_string(self):

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -9,11 +9,11 @@ from llsd.base import (_LLSD, LLSDBaseParser, LLSDSerializationError, BINARY_HEA
 
 
 try:
-    # Python 2
-    xrange
+    # Python 2: make 'range()' lazy like Python 3
+    range = xrange
 except NameError:
-    # Python 3
-    xrange = range
+    # Python 3: 'range()' is already lazy
+    pass
 
 
 class LLSDBinaryParser(LLSDBaseParser):
@@ -116,7 +116,7 @@ class LLSDBinaryParser(LLSDBaseParser):
         "Parse a single llsd array"
         rv = []
         size = struct.unpack("!i", self._getc(4))[0]
-        for count in xrange(size):
+        for count in range(size):
             rv.append(self._parse())
         if self._getc() != b']':
             self._error("invalid array close token")

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -71,15 +71,16 @@ class LLSDNotationParser(LLSDBaseParser):
         for c, func in _dispatch_dict.items():
             self._dispatch[ord(c)] = func
 
-    def parse(self, baseparser, ignore_binary = False):
+    def parse(self, something, ignore_binary = False):
         """
         This is the basic public interface for parsing.
 
-        :param baseparser: LLSDBaseParser or subclass holding data to parse.
+        :param something: serialized LLSD to parse: a bytes object, a binary
+                          stream or an LLSDBaseParser subclass.
         :param ignore_binary: parser throws away data in llsd binary nodes.
         :returns: returns a python object.
         """
-        self._reset(baseparser)
+        self._reset(something)
 
         # EOF is an acceptable result
         cc = self._getc(full=False)


### PR DESCRIPTION
Instead of peeking ahead by a character and then (most of the time) rereading it simply to discard it, go ahead and read the next character, passing it into the various LLSDNotationParser._parse_mumble() functions. This eliminates most LLSDNotationParser use of LLSDBaseParser._peek(), save for _get_re().

This eliminates the need for LLSDNotationParser._skip_then(), whose only job was to discard the next character and return the specified value.

Break out LLSDNotationParser._parse_true() and _parse_false() in anticipation of potential reimplementation without _get_re().