### PR TITLE
Use CODECOV_TOKEN to address flaky uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: PYTHON
           fail_ci_if_error: true
           files: .coverage.${{ steps.pyenv.outputs.value }}.xml


### PR DESCRIPTION
Codecov uploads appear to be failing commonly when using tokenless uploads. Let's try adorning our coverage uploads with a token to see if it improves reliability.