### PR TITLE
SL-18330: In XML formatter, avoid adding call stack depth.

### DIFF
--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -1345,6 +1345,20 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
                                   map_within_map_xml)
         self.assertXMLRoundtrip({}, blank_map_xml)
 
+    def testDeepMap(self):
+        """
+        Test that formatting a deeply nested map does not cause a RecursionError
+        """
+
+        test_map = {"foo":"bar", "depth":0, "next":None}
+        max_depth = 200
+        for depth in range(max_depth):
+            test_map = {"foo":"bar", "depth":depth, "next":test_map}
+
+        # this should not throw an exception.
+        test_xml = self.llsd.as_xml(test_map)
+
+
     def testBinary(self):
         """
         Test the parse and serialization of input type : binary.


### PR DESCRIPTION
Making `LLSDXMLFormatter._elt()` accept a lambda was a tricky way to minimize
source changes to existing `_elt()` calls in `_ARRAY()` and `_MAP()`. The trouble is
that that added function entries for each level of a deeply-nested LLSD
structure -- and with our users, we unfortunately do encounter deeply-nested
large inventories. Log observed `RecursionError` failures in AIS.

Explicitly write out the individual sequence of calls in `_ARRAY()`, `_MAP()` and
the top-level `_write()`, the only callers to pass lambdas to `_elt()`.