### PR TITLE
SRV-439 - performance optimizations for string handling in xml formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
+          set
           git tag
           pip install --upgrade pip
           pip install wheel build tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          set
-          git tag
+          apt-get update
+          apt-get -y install sudo
           pip install --upgrade pip
-          pip install wheel build tox
-          pip install .[dev]
+          sudo -H pip install wheel build tox
+          sudo -H pip install .[dev]
 
       - name: Determine pyenv
         id: pyenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
         python-version: ['2.7', '3.7', '3.8', '3.10']
         container: ["python:2.7", "python:3.7", "python:3.8", "python:3.10"]
     runs-on: [ubuntu-latest]
-      container:
-        image: ${{ matrix.containert }}
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
         python-version: ['2.7', '3.7', '3.8', '3.10']
         container: ["python:2.7", "python:3.7", "python:3.8", "python:3.10"]
     runs-on: [ubuntu-latest]
+    container:
+      image: ${{ matrix.containert }}
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
           apt-get update
           apt-get -y install sudo
           pip install --upgrade pip
+          git config --global --add safe.directory .
           sudo git tag
           sudo -H pip install wheel build tox
           ls -la

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           ls -la
           set
           pip install --upgrade pip
-          sudo chown . root
+          sudo chown root .
           git tag
           sudo -H pip install wheel build tox
           ls -la

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
           apt-get -y install sudo
           pip install --upgrade pip
           sudo -H pip install wheel build tox
+          ls -la
           sudo -H pip install .[dev]
 
       - name: Determine pyenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: ['2.7', '3.7', '3.8', '3.10']
     runs-on: [ubuntu-latest]
     container:
-      image: "python:${{ matrix.python-version }}"
+      image: "python:${{ matrix.python-version }}-buster"
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,6 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          python -m venv /tmp/venv
-          source /tmp/venv/bin/activate
-          echo "VIRTUAL ENV: $VIRTUAL_ENV"
           ls -la /home
           set
           pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
           pip install --upgrade pip
           sudo chown root .
           git tag
+          git status
           sudo -H pip install wheel build tox
           ls -la
           sudo -H pip install .[dev]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
           apt-get update
           apt-get -y install sudo
           pip install --upgrade pip
+          sudo git tag
           sudo -H pip install wheel build tox
           ls -la
           sudo -H pip install .[dev]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.10']
+        container: ["python:2.7", "python:3.7", "python:3.8", "python:3.10"]
     runs-on: [ubuntu-latest]
       container:
-        image: 'python:${{ matrix.python-version }}'
+        image: ${{ matrix.containert }}
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,9 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          ls -la
-          set
           pip install --upgrade pip
           sudo chown root .
-          git tag
-          git status
           sudo -H pip install wheel build tox
-          ls -la
           sudo -H pip install .[dev]
 
       - name: Determine pyenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,6 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history for setuptools_scm to be able to read tags
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install python dependencies
         run: |
           apt-get update

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install wheel build tox
-          pip install .[dev]
+          sudo -H pip install wheel build tox
+          sudo -H pip install .[dev]
 
       - name: Determine pyenv
         id: pyenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,9 @@ jobs:
           git config --global --add safe.directory '*'
           echo "DONE MARKING DIRECTORIES AS SAFE"
           ls -la /home
+          echo $USER
           pip install --upgrade pip
-          sudo git tag
+          sudo -H git tag
           sudo -H pip install wheel build tox
           ls -la
           sudo -H pip install .[dev]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
+          python -m venv /tmp/venv
+          source /tmp/venv/bin/activate
           echo "MARKING DIRECTORIES AS SAFE"
           git config --global --add safe.directory '*'
           echo "DONE MARKING DIRECTORIES AS SAFE"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,10 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          ls -la /home
+          ls -la
           set
           pip install --upgrade pip
-          sudo -H git tag
+          git tag
           sudo -H pip install wheel build tox
           ls -la
           sudo -H pip install .[dev]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: ['2.7', '3.7', '3.8', '3.10']
     runs-on: [ubuntu-latest]
     container:
-      image: "python:${{ matrix.python-version }}-alpine"
+      image: "python:${{ matrix.python-version }}"
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
+          pip install --upgrade pip
           pip install wheel build tox
           pip install .[dev]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
+          git tag
           pip install --upgrade pip
           pip install wheel build tox
           pip install .[dev]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.10']
-        container: ["python:2.7", "python:3.7", "python:3.8", "python:3.10"]
     runs-on: [ubuntu-latest]
     container:
-      image: ${{ matrix.containert }}
+      image: "python:${{ matrix.python-version }}"
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.10']
     runs-on: [ubuntu-latest]
+      container: python:${{ matrix.python-version }}
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
+          git config --global --add safe.directory /__w/python-llsd/python-llsd
           pip install --upgrade pip
-          git config --global --add safe.directory .
           sudo git tag
           sudo -H pip install wheel build tox
           ls -la

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: ['2.7', '3.7', '3.8', '3.10']
     runs-on: [ubuntu-latest]
     container:
-      image: "python:${{ matrix.python-version }}"
+      image: "python:${{ matrix.python-version }}-alpine"
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.10']
     runs-on: [ubuntu-latest]
-      container: python:${{ matrix.python-version }}
+      container:
+        image: 'python:${{ matrix.python-version }}'
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           git config --global --add safe.directory '*'
           echo "DONE MARKING DIRECTORIES AS SAFE"
           ls -la /home
-          echo $USER
+          who
           pip install --upgrade pip
           sudo -H git tag
           sudo -H pip install wheel build tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,10 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
+          echo "MARKING DIRECTORIES AS SAFE"
           git config --global --add safe.directory '*'
+          echo "DONE MARKING DIRECTORIES AS SAFE"
+          ls -la /home
           pip install --upgrade pip
           sudo git tag
           sudo -H pip install wheel build tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,9 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          sudo -H pip install wheel build tox
-          sudo -H pip install .[dev]
+          pip install --upgrade pip
+          pip install wheel build tox
+          pip install .[dev]
 
       - name: Determine pyenv
         id: pyenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,13 +26,11 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          sudo python -m venv /tmp/venv
-          sudo source /tmp/venv/bin/activate
-          echo "MARKING DIRECTORIES AS SAFE"
-          git config --global --add safe.directory '*'
-          echo "DONE MARKING DIRECTORIES AS SAFE"
+          python -m venv /tmp/venv
+          source /tmp/venv/bin/activate
+          echo "VIRTUAL ENV: $VIRTUAL_ENV"
           ls -la /home
-          who
+          set
           pip install --upgrade pip
           sudo -H git tag
           sudo -H pip install wheel build tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          git config --global --add safe.directory /__w/python-llsd/python-llsd
+          git config --global --add safe.directory '*'
           pip install --upgrade pip
           sudo git tag
           sudo -H pip install wheel build tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           apt-get update
           apt-get -y install sudo
-          python -m venv /tmp/venv
-          source /tmp/venv/bin/activate
+          sudo python -m venv /tmp/venv
+          sudo source /tmp/venv/bin/activate
           echo "MARKING DIRECTORIES AS SAFE"
           git config --global --add safe.directory '*'
           echo "DONE MARKING DIRECTORIES AS SAFE"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
           ls -la
           set
           pip install --upgrade pip
+          sudo chown . root
           git tag
           sudo -H pip install wheel build tox
           ls -la

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install --upgrade pip
           pip install wheel build tox
           pip install .[dev]
 

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -317,7 +317,7 @@ NODE_HANDLERS = dict(
 def _to_python(node, depth=0):
     "Convert node to a python object."
     if depth > MAX_PARSE_DEPTH:
-        raise LLSDSerializationError("Cannot serialize depth of more than %d" % MAX_FORMAT_DEPTH)
+        raise LLSDParseError("Cannot parse depth of more than %d" % MAX_FORMAT_DEPTH)
 
     return NODE_HANDLERS[node.tag](node, depth)
 

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -317,7 +317,7 @@ NODE_HANDLERS = dict(
 def _to_python(node, depth=0):
     "Convert node to a python object."
     if depth > MAX_PARSE_DEPTH:
-        raise LLSDParseError("Cannot parse depth of more than %d" % MAX_FORMAT_DEPTH)
+        raise LLSDParseError("Cannot parse depth of more than %d" % MAX_PARSE_DEPTH)
 
     return NODE_HANDLERS[node.tag](node, depth)
 

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -31,7 +31,7 @@ NOTATION_HEADER = b'<? llsd/notation ?>'
 
 ALL_CHARS = str(bytearray(range(256))) if PY2 else bytes(range(256))
 
-
+MAX_FORMAT_DEPTH = 200
 class _LLSD:
     __metaclass__ = abc.ABCMeta
 

--- a/llsd/base.py
+++ b/llsd/base.py
@@ -317,7 +317,7 @@ NODE_HANDLERS = dict(
 def _to_python(node, depth=0):
     "Convert node to a python object."
     if depth > MAX_PARSE_DEPTH:
-        raise LLSDParseError("Cannot serialize depth of more than %d" % MAX_FORMAT_DEPTH)
+        raise LLSDSerializationError("Cannot serialize depth of more than %d" % MAX_FORMAT_DEPTH)
 
     return NODE_HANDLERS[node.tag](node, depth)
 

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -83,7 +83,7 @@ class LLSDBinaryParser(LLSDBaseParser):
     def _parse(self):
         "The actual parser which is called recursively when necessary."
         if self._depth > MAX_PARSE_DEPTH:
-            self._error("Parse depth exceeded max.")
+            self._error("Parse depth exceeded maximum depth of %d." % MAX_PARSE_DEPTH)
 
         cc = self._getc()
         try:
@@ -100,7 +100,7 @@ class LLSDBinaryParser(LLSDBaseParser):
         count = 0
         cc = self._getc()
         key = b''
-        self._depth = self._depth + 1
+        self._depth += 1
         while (cc != b'}') and (count < size):
             if cc == b'k':
                 key = self._parse_string()
@@ -114,7 +114,7 @@ class LLSDBinaryParser(LLSDBaseParser):
             cc = self._getc()
         if cc != b'}':
             self._error("invalid map close token")
-        self._depth = self._depth - 1
+        self._depth -= 1
         return rv
 
     def _parse_array(self):

--- a/llsd/serde_binary.py
+++ b/llsd/serde_binary.py
@@ -120,13 +120,13 @@ class LLSDBinaryParser(LLSDBaseParser):
     def _parse_array(self):
         "Parse a single llsd array"
         rv = []
-        self._depth = self._depth + 1
+        self._depth += 1
         size = struct.unpack("!i", self._getc(4))[0]
         for count in range(size):
             rv.append(self._parse())
         if self._getc() != b']':
             self._error("invalid array close token")
-        self._depth = self._depth - 1
+        self._depth -= 1
         return rv
 
     def _parse_string(self):

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -185,7 +185,7 @@ class LLSDNotationParser(LLSDBaseParser):
         rv = {}
         key = b''
         found_key = False
-        self._depth = self._depth + 1
+        self._depth += 1
         # skip the beginning '{'
         cc = self._getc()
         while (cc != b'}'):
@@ -211,7 +211,7 @@ class LLSDNotationParser(LLSDBaseParser):
             else:
                 self._error("missing separator")
             cc = self._getc()
-        self._depth = self._depth - 1
+        self._depth -= 1
 
         return rv
 
@@ -222,7 +222,7 @@ class LLSDNotationParser(LLSDBaseParser):
         array: [ object, object, object ]
         """
         rv = []
-        self._depth = self._depth + 1
+        self._depth += 1
         # skip the beginning '['
         cc = self._getc()
         while (cc != b']'):
@@ -233,7 +233,7 @@ class LLSDNotationParser(LLSDBaseParser):
                 continue
             rv.append(self._parse(cc))
             cc = self._getc()
-        self._depth = self._depth - 1
+        self._depth -= 1
         return rv
 
     def _parse_uuid(self, cc):
@@ -454,22 +454,22 @@ class LLSDNotationFormatter(LLSDBaseFormatter):
     def _ARRAY(self, v):
         self.stream.write(b'[')
         delim = b''
-        self._depth = self._depth + 1
+        self._depth += 1
         for item in v:
             self.stream.write(delim)
             self._generate(item)
             delim = b','
-        self._depth = self._depth - 1
+        self._depth -= 1
         self.stream.write(b']')
     def _MAP(self, v):
         self.stream.write(b'{')
         delim = b''
-        self._depth = self._depth + 1
+        self._depth += 1
         for key, value in v.items():
             self.stream.writelines([delim, b"'", self._esc(UnicodeType(key)), b"':"])
             self._generate(value)
             delim = b','
-        self._depth = self._depth - 1
+        self._depth -= 1
         self.stream.write(b'}')
 
     def _esc(self, data, quote=b"'"):

--- a/llsd/serde_notation.py
+++ b/llsd/serde_notation.py
@@ -109,7 +109,7 @@ class LLSDNotationParser(LLSDBaseParser):
     def _parse(self, cc):
         "The notation parser workhorse."
         if self._depth > MAX_PARSE_DEPTH:
-            self._error("Parse depth exceeded max.")
+            self._error("Parse depth exceeded max of %d" % MAX_PARSE_DEPTH)
         try:
             func = self._dispatch[ord(cc)]
         except IndexError:

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -177,17 +177,14 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
     This class is not necessarily suited for serializing very large objects.
     It sorts on dict (llsd map) keys alphabetically to ease human reading.
     """
-    def __init__(self, indent_atom = None):
+    def __init__(self, indent_atom = b'  '):
         "Construct a pretty serializer."
         # Call the super class constructor so that we have the type map
         super(LLSDXMLPrettyFormatter, self).__init__()
 
         # Private data used for indentation.
         self._indent_level = 1
-        if indent_atom is None:
-            self._indent_atom = b'  '
-        else:
-            self._indent_atom = indent_atom
+        self._indent_atom = indent_atom
         self._eol = b'\n'
 
     def _indent(self):

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -98,18 +98,18 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
         self.stream.writelines([b'<uuid>', str(v).encode('utf-8'), b'</uuid>', self._eol])
     def _BINARY(self, v):
         self.stream.writelines([b'<binary>', base64.b64encode(v).strip(), b'</binary>', self._eol])
-    def _STRING(self, v):
-        # We don't simply have a function that encapsulates the PY2 vs PY3 calls,
-        # as that results in another function call and is slightly less performant
-        if PY2:    # pragma: no cover
+        
+    if PY2:
+        def _STRING(self, v):
             return self.stream.writelines([b'<string>', _str_to_bytes(xml_esc(v)), b'</string>', self._eol])
-        self.stream.writelines([b'<string>', v.translate(XML_ESC_TRANS).encode('utf-8'), b'</string>', self._eol])
-    def _URI(self, v):
-        # We don't simply have a function that encapsulates the PY2 vs PY3 calls,
-        # as that results in another function call and is slightly less performant
-        if PY2:    # pragma: no cover
+        def _URI(self, v):
             return self.stream.writelines([b'<uri>', _str_to_bytes(xml_esc(v)), b'</uri>', self._eol])
-        self.stream.writelines([b'<uri>', str(v).translate(XML_ESC_TRANS).encode('utf-8'), b'</uri>', self._eol])
+    else:
+        def _STRING(self, v):
+            self.stream.writelines([b'<string>', v.translate(XML_ESC_TRANS).encode('utf-8'), b'</string>', self._eol])
+        def _URI(self, v):
+            self.stream.writelines([b'<uri>', str(v).translate(XML_ESC_TRANS).encode('utf-8'), b'</uri>', self._eol])
+    
     def _DATE(self, v):
         self.stream.writelines([b'<date>', _format_datestr(v), b'</date>', self._eol])
     def _ARRAY(self, v):

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -69,12 +69,12 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
     interface to this functionality.
     """
 
-    def __init__(self, indent_atom = None):
+    def __init__(self, indent_atom = b'', eol = b''):
         "Construct a serializer."
         # Call the super class constructor so that we have the type map
         super(LLSDXMLFormatter, self).__init__()
-        self._indent_atom = b''
-        self._eol = b''
+        self._indent_atom = indent_atom
+        self._eol = eol
         self._depth = 1
 
     def _indent(self):
@@ -178,14 +178,10 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
     This class is not necessarily suited for serializing very large objects.
     It sorts on dict (llsd map) keys alphabetically to ease human reading.
     """
-    def __init__(self, indent_atom = b'  '):
+    def __init__(self, indent_atom = b'  ', eol = b'\n'):
         "Construct a pretty serializer."
         # Call the super class constructor so that we have the type map
-        super(LLSDXMLPrettyFormatter, self).__init__()
-
-        # Private data used for indentation.
-        self._indent_atom = indent_atom
-        self._eol = b'\n'
+        super(LLSDXMLPrettyFormatter, self).__init__(indent_atom = indent_atom, eol = eol)
 
     def _indent(self):
         "Write an indentation based on the atom and indentation level."

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -1,11 +1,13 @@
 import base64
+import binascii
+from collections import deque
 import io
 import re
-import types
+import uuid
 
 from llsd.base import (_LLSD, ALL_CHARS, LLSDBaseParser, LLSDBaseFormatter, XML_HEADER,
                        LLSDParseError, LLSDSerializationError, UnicodeType,
-                       _format_datestr, _str_to_bytes, _to_python, is_unicode)
+                       _format_datestr, _str_to_bytes, is_unicode, PY2, uri, binary, _parse_datestr)
 from llsd.fastest_elementtree import ElementTreeError, fromstring, parse as _parse
 
 INVALID_XML_BYTES = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c'\
@@ -14,7 +16,22 @@ INVALID_XML_BYTES = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c'\
 INVALID_XML_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 
 
+XML_ESC_TRANS = {}
+if not PY2:
+    XML_ESC_TRANS = str.maketrans({'&': '&amp;',
+                                   '<':'&lt;',
+                                   '>':'&gt;',
+                                   u'\uffff':None,   # cannot be parsed
+                                   u'\ufffe':None})  # cannot be parsed
+
+    for x in INVALID_XML_BYTES:
+        XML_ESC_TRANS[x] = None
+
+
 def remove_invalid_xml_bytes(b):
+    """
+    Remove characters that aren't allowed in xml.
+    """
     try:
         # Dropping chars that cannot be parsed later on.  The
         # translate() function was benchmarked to be the fastest way
@@ -24,6 +41,24 @@ def remove_invalid_xml_bytes(b):
         # we get here if s is a unicode object (should be limited to
         # unit tests)
         return INVALID_XML_RE.sub('', b)
+
+# only python2, which is not covered by coverage tests
+def xml_esc(v): # pragma: no cover
+    "Escape string or unicode object v for xml output"
+
+    # Use is_unicode() instead of is_string() because in python 2, str is
+    # bytes, not unicode, and should not be "encode()"d. Attempts to
+    # encode("utf-8") a bytes type will result in an implicit
+    # decode("ascii") that will throw a UnicodeDecodeError if the string
+    # contains non-ascii characters.
+    if is_unicode(v):
+        # we need to drop these invalid characters because they
+        # cannot be parsed (and encode() doesn't drop them for us)
+        v = v.replace(u'\uffff', u'')
+        v = v.replace(u'\ufffe', u'')
+        v = v.encode('utf-8')
+    v = remove_invalid_xml_bytes(v)
+    return v.replace(b'&',b'&amp;').replace(b'<',b'&lt;').replace(b'>',b'&gt;')
 
 
 class LLSDXMLFormatter(LLSDBaseFormatter):
@@ -37,75 +72,78 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
     this class since the module level format_xml() is the most convenient
     interface to this functionality.
     """
-    def _elt(self, name, contents=None):
-        """
-        Serialize a single element.
 
-        If 'contents' is omitted, write <name/>.
-        If 'contents' is bytes, write <name>contents</name>.
-        If 'contents' is str, write <name>contents.encode('utf8')</name>.
-        """
-        if not contents:
-            self.stream.writelines([b"<", name, b" />"])
-        else:
-            self.stream.writelines([b"<", name, b">",
-                                    _str_to_bytes(contents),
-                                    b"</", name, b">"])
+    def __init__(self, indent_atom = None):
+        "Construct a serializer."
+        # Call the super class constructor so that we have the type map
+        super(LLSDXMLFormatter, self).__init__()
+        self._indent_atom = b''
+        self._eol = b''
+        self._indent_level = 0
 
-    def xml_esc(self, v):
-        "Escape string or unicode object v for xml output"
-
-        # Use is_unicode() instead of is_string() because in python 2, str is
-        # bytes, not unicode, and should not be "encode()"d. Attempts to
-        # encode("utf-8") a bytes type will result in an implicit
-        # decode("ascii") that will throw a UnicodeDecodeError if the string
-        # contains non-ascii characters.
-        if is_unicode(v):
-            # we need to drop these invalid characters because they
-            # cannot be parsed (and encode() doesn't drop them for us)
-            v = v.replace(u'\uffff', u'')
-            v = v.replace(u'\ufffe', u'')
-            v = v.encode('utf-8')
-        v = remove_invalid_xml_bytes(v)
-        return v.replace(b'&',b'&amp;').replace(b'<',b'&lt;').replace(b'>',b'&gt;')
+    def _indent(self):
+        pass
 
     def _LLSD(self, v):
         return self._generate(v.thing)
     def _UNDEF(self, _v):
-        return self._elt(b'undef')
+        self.stream.writelines([b'<undef/>', self._eol])
     def _BOOLEAN(self, v):
         if v:
-            return self._elt(b'boolean', b'true')
-        else:
-            return self._elt(b'boolean', b'false')
+            return self.stream.writelines([b'<boolean>true</boolean>', self._eol])
+        self.stream.writelines([b'<boolean>false</boolean>', self._eol])
     def _INTEGER(self, v):
-        return self._elt(b'integer', str(v))
+        self.stream.writelines([b'<integer>', str(v).encode('utf-8'), b'</integer>', self._eol])
     def _REAL(self, v):
-        return self._elt(b'real', repr(v))
+        self.stream.writelines([b'<real>', str(v).encode('utf-8'),  b'</real>', self._eol])
     def _UUID(self, v):
         if v.int == 0:
-            return self._elt(b'uuid')
-        else:
-            return self._elt(b'uuid', str(v))
+            return self.stream.writelines([b'<uuid/>', self._eol])
+        self.stream.writelines([b'<uuid>', str(v).encode('utf-8'), b'</uuid>', self._eol])
     def _BINARY(self, v):
-        return self._elt(b'binary', base64.b64encode(v).strip())
+        self.stream.writelines([b'<binary>', base64.b64encode(v).strip(), b'</binary>', self._eol])
     def _STRING(self, v):
-        return self._elt(b'string', self.xml_esc(v))
+        # We don't simply have a function that encapsulates the PY2 vs PY3 calls,
+        # as that results in another function call and is slightly less performant
+        if PY2:    # pragma: no cover
+            return self.stream.writelines([b'<string>', _str_to_bytes(xml_esc(v)), b'</string>', self._eol])
+        self.stream.writelines([b'<string>', v.translate(XML_ESC_TRANS).encode('utf-8'), b'</string>', self._eol])
     def _URI(self, v):
-        return self._elt(b'uri', self.xml_esc(str(v)))
+        # We don't simply have a function that encapsulates the PY2 vs PY3 calls,
+        # as that results in another function call and is slightly less performant
+        if PY2:    # pragma: no cover
+            return self.stream.writelines([b'<uri>', _str_to_bytes(xml_esc(v)), b'</uri>', self._eol])
+        self.stream.writelines([b'<uri>', str(v).translate(XML_ESC_TRANS).encode('utf-8'), b'</uri>', self._eol])
     def _DATE(self, v):
-        return self._elt(b'date', _format_datestr(v))
+        self.stream.writelines([b'<date>', _format_datestr(v), b'</date>', self._eol])
     def _ARRAY(self, v):
-        self.stream.write(b'<array>')
+        self.stream.writelines([b'<array>', self._eol])
+        self._indent_level = self._indent_level + 1
         for item in v:
+            self._indent()
             self._generate(item)
-        self.stream.write(b'</array>')
+        self._indent_level = self._indent_level - 1
+        self.stream.writelines([b'</array>', self._eol])
     def _MAP(self, v):
-        self.stream.write(b'<map>')
+        self.stream.writelines([b'<map>', self._eol])
+        self._indent_level = self._indent_level + 1
         for key, value in v.items():
-            self._elt(b'key', self.xml_esc(UnicodeType(key)))
+            self._indent()
+            if PY2:     # pragma: no cover
+                self.stream.writelines([b'<key>',
+                                        xml_esc(UnicodeType(key)),
+                                        b'</key>',
+                                        self._eol])
+            else:
+                self.stream.writelines([b'<key>',
+                                        UnicodeType(key).translate(XML_ESC_TRANS).encode('utf-8'),
+                                        b'</key>',
+                                        self._eol])
+            self._indent()
             self._generate(value)
-        self.stream.write(b'</map>')
+        self._indent_level = self._indent_level - 1
+        self._indent()
+        self.stream.writelines([b'</map>', self._eol])
 
     def _generate(self, something):
         "Generate xml from a single python object."
@@ -121,11 +159,10 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
     def _write(self, something):
         """
         Serialize a python object to self.stream as application/llsd+xml.
-
         :param something: A python object (typically a dict) to be serialized.
         """
-        self.stream.write(b'<?xml version="1.0" ?>'
-                          b'<llsd>')
+        self.stream.writelines([b'<?xml version="1.0" ?>', self._eol,
+                                b'<llsd>', self._eol])
         self._generate(something)
         self.stream.write(b'</llsd>')
 
@@ -154,48 +191,11 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
             self._indent_atom = b'  '
         else:
             self._indent_atom = indent_atom
+        self._eol = b'\n'
 
     def _indent(self):
         "Write an indentation based on the atom and indentation level."
         self.stream.writelines([self._indent_atom] * self._indent_level)
-
-    def _ARRAY(self, v):
-        "Recursively format an array with pretty turned on."
-        self.stream.write(b'<array>\n')
-        self._indent_level += 1
-        for item in v:
-            self._indent()
-            self._generate(item)
-            self.stream.write(b'\n')
-        self._indent_level -= 1
-        self._indent()
-        self.stream.write(b'</array>')
-
-    def _MAP(self, v):
-        "Recursively format a map with pretty turned on."
-        self.stream.write(b'<map>\n')
-        self._indent_level += 1
-        # sorted list of keys
-        for key in sorted(v):
-            self._indent()
-            self._elt(b'key', UnicodeType(key))
-            self.stream.write(b'\n')
-            self._indent()
-            self._generate(v[key])
-            self.stream.write(b'\n')
-        self._indent_level -= 1
-        self._indent()
-        self.stream.write(b'</map>')
-
-    def _write(self, something):
-        """
-        Serialize a python object to self.stream as 'pretty' application/llsd+xml.
-
-        :param something: a python object (typically a dict) to be serialized.
-        """
-        self.stream.write(b'<?xml version="1.0" ?>\n<llsd>')
-        self._generate(something)
-        self.stream.write(b'</llsd>\n')
 
 
 def format_pretty_xml(something):
@@ -237,6 +237,168 @@ def write_pretty_xml(stream, something):
     return LLSDXMLPrettyFormatter().write(stream, something)
 
 
+class LLSDXMLParser:
+    def __init__(self):
+        "Construct an xml node parser."
+
+        self.NODE_HANDLERS = {
+            "undef": lambda x: None,
+            "boolean": self._bool_to_python,
+            "integer": self._int_to_python,
+            "real": self._real_to_python,
+            "uuid": self._uuid_to_python,
+            "string": self._str_to_python,
+            "binary": self._bin_to_python,
+            "date": self._date_to_python,
+            "uri": self._uri_to_python,
+            "map": self._map_to_python,
+            "array": self._array_to_python,
+        }
+
+        self.parse_stack = deque([])
+
+    def _bool_to_python(self, node):
+        "Convert boolean node to a python object."
+        val = node.text or ''
+        try:
+            # string value, accept 'true' or 'True' or whatever
+            return (val.lower() in ('true', '1', '1.0'))
+        except AttributeError:
+            # not a string (no lower() method), use normal Python rules
+            return bool(val)
+
+    def _int_to_python(self, node):
+        "Convert integer node to a python object."
+        val = node.text or ''
+        if not val.strip():
+            return 0
+        return int(val)
+
+    def _real_to_python(self, node):
+        "Convert floating point node to a python object."
+        val = node.text or ''
+        if not val.strip():
+            return 0.0
+        return float(val)
+
+    def _uuid_to_python(self, node):
+        "Convert uuid node to a python object."
+        if node.text:
+            return uuid.UUID(hex=node.text)
+        return uuid.UUID(int=0)
+
+    def _str_to_python(self, node):
+        "Convert string node to a python object."
+        return node.text or ''
+
+    def _bin_to_python(self, node):
+        base = node.get('encoding') or 'base64'
+        try:
+            if base == 'base16':
+                # parse base16 encoded data
+                return binary(base64.b16decode(node.text or ''))
+            if base == 'base64':
+                # parse base64 encoded data
+                return binary(base64.b64decode(node.text or ''))
+            raise LLSDParseError("Parser doesn't support %s encoding" % base)
+
+        except binascii.Error as exc:
+            # convert exception class so it's more catchable
+            raise LLSDParseError("Encoded binary data: " + str(exc))
+        except TypeError as exc:
+            # convert exception class so it's more catchable
+            raise LLSDParseError("Bad binary data: " + str(exc))
+
+    def _date_to_python(self, node):
+        "Convert date node to a python object."
+        val = node.text or ''
+        if not val:
+            val = "1970-01-01T00:00:00Z"
+        return _parse_datestr(val)
+
+    def _uri_to_python(self, node):
+        "Convert uri node to a python object."
+        val = node.text or ''
+        return uri(val)
+
+    def _map_to_python(self, node):
+        "Convert map node to a python object."
+        new_result = {}
+        new_stack_entry = [iter(node), node, new_result]
+        self.parse_stack.appendleft(new_stack_entry)
+        return new_result
+
+    def _array_to_python(self, node):
+        "Convert array node to a python object."
+        new_result = []
+        new_stack_entry = [iter(node), node, new_result]
+        self.parse_stack.appendleft(new_stack_entry)
+        return new_result
+
+    def parse_node(self, something):
+        """
+        Parse an ElementTree tree
+        This parser is iterative instead of recursive. It uses
+        Each element in parse_stack is an iterator into either the list
+        or the dict in the tree. This limits depth by size of free memory 
+        instead of size of the function call stack, allowing us to render
+        deeper trees than a recursive model.
+        :param something: The xml node to parse.
+        :returns: Returns a python object.
+        """
+
+        # if the passed in element is not a map or array, simply return
+        # its value.  Otherwise, create a dict or array to receive
+        # child/leaf elements.
+        if something.tag == "map":
+            cur_result = {}
+        elif something.tag == "array":
+            cur_result = []
+        else:
+            if something.tag not in self.NODE_HANDLERS:
+                raise LLSDParseError("Unknown value type %s" % something.tag)
+            return self.NODE_HANDLERS[something.tag](something)
+
+        # start by pushing the current element iterator data onto
+        # the stack
+        # 0 - iterator indicating the current position in the given level of the tree
+        #     this can be either a list iterator position, or an iterator of
+        #     keys for the dict.
+        # 1 - the actual element object.
+        # 2 - the result for this level in the tree, onto which
+        #     children or leafs will be appended/set
+        self.parse_stack.appendleft([iter(something), something, cur_result])
+        while True:
+            node_iter, iterable, cur_result = self.parse_stack[0]
+            try:
+                value = next(node_iter)
+
+            except StopIteration:
+                node_iter, iterable, cur_result = self.parse_stack.popleft()
+                if len(self.parse_stack) == 0:
+                    break
+            else:
+                if iterable.tag == "map":
+                    if value.tag != "key":
+                        raise LLSDParseError("Expected 'key', got %s" % value.tag)
+                    key = value.text
+                    if key is None:
+                        key = ''
+                    try:
+                        value = next(node_iter)
+                    except StopIteration:
+                        raise LLSDParseError("No value for map item %s" % key)
+                    try:
+                        cur_result[key] = self.NODE_HANDLERS[value.tag](value)
+                    except KeyError as err:
+                        raise LLSDParseError("Unknown value type: " + str(err))
+                elif iterable.tag == "array":
+                    try:
+                        cur_result.append(self.NODE_HANDLERS[value.tag](value))
+                    except KeyError as err:
+                        raise LLSDParseError("Unknown value type: " + str(err))
+        return cur_result
+
 def parse_xml(something):
     """
     This is the basic public interface for parsing llsd+xml.
@@ -250,6 +412,8 @@ def parse_xml(something):
     # If we matched the header, then parse whatever follows, else parse the
     # original bytes object or stream.
     return parse_xml_nohdr(parser)
+
+
 
 
 def parse_xml_nohdr(baseparser):
@@ -280,7 +444,7 @@ def parse_xml_nohdr(baseparser):
     if element.tag != 'llsd':
         raise LLSDParseError("Invalid XML Declaration")
     # Extract its contents.
-    return _to_python(element[0])
+    return LLSDXMLParser().parse_node(element[0])
 
 
 def format_xml(something):

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -114,15 +114,15 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
         self.stream.writelines([b'<date>', _format_datestr(v), b'</date>', self._eol])
     def _ARRAY(self, v):
         self.stream.writelines([b'<array>', self._eol])
-        self._depth = self._depth + 1
+        self._depth += 1
         for item in v:
             self._indent()
             self._generate(item)
-        self._depth = self._depth - 1
+        self._depth -= 1
         self.stream.writelines([b'</array>', self._eol])
     def _MAP(self, v):
         self.stream.writelines([b'<map>', self._eol])
-        self._depth = self._depth + 1
+        self._depth += 1
         for key, value in v.items():
             self._indent()
             if PY2:     # pragma: no cover
@@ -137,7 +137,7 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
                                         self._eol])
             self._indent()
             self._generate(value)
-        self._depth = self._depth - 1
+        self._depth -= 1
         self._indent()
         self.stream.writelines([b'</map>', self._eol])
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     setup_requires=["setuptools_scm<6"],
     use_scm_version={
         'local_scheme': 'no-local-version', # disable local-version to allow uploads to test.pypi.org
+        'version_scheme': 'post-release',
+        'relative_to': __file__,
+        'root': '..',
     },
     extras_require={
         "dev": ["pytest", "pytest-benchmark", "pytest-cov<3"],

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ setup(
     setup_requires=["setuptools_scm<6"],
     use_scm_version={
         'local_scheme': 'no-local-version', # disable local-version to allow uploads to test.pypi.org
-        'version_scheme': 'post-release',
-        'relative_to': __file__,
-        'root': '..',
     },
     extras_require={
         "dev": ["pytest", "pytest-benchmark", "pytest-cov<3"],

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -45,6 +45,9 @@ BENCH_DATA_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 </llsd>"""
 
 _bench_data = llsd.parse_xml(BENCH_DATA_XML)
+
+    
+    
 BENCH_DATA_BINARY = llsd.format_binary(_bench_data)
 BENCH_DATA_NOTATION = llsd.format_notation(_bench_data)
 
@@ -78,6 +81,40 @@ def binary_stream():
         f.seek(0)
         yield f
 
+def build_deep_xml():
+    deep_data = {}
+    curr_data = deep_data
+    for i in range(250):
+        curr_data["curr_data"] = {}
+        curr_data["integer"] = 7
+        curr_data["string"] = "string"
+        curr_data["map"] = { "item1": 2.345, "item2": [1,2,3], "item3": {"item4": llsd.uri("http://foo.bar.com")}}
+        curr_data = curr_data["curr_data"]
+        
+    return deep_data
+_deep_bench_data = build_deep_xml()
+
+def build_wide_xml():
+    
+    wide_xml = b"""
+<?xml version="1.0" encoding="UTF-8"?><llsd><map><key>wide_array</key><array>"
+"""
+    wide_data = {}
+    for i in range(100000):
+        wide_data["item"+str(i)] = {"item1":2.345, "item2": [1,2,3], "item3": "string", "item4":{"subitem": llsd.uri("http://foo.bar.com")}}
+    return wide_data
+_wide_bench_data = build_wide_xml()
+
+def build_wide_array_xml():
+    
+    wide_xml = b"""
+<?xml version="1.0" encoding="UTF-8"?><llsd><map><key>wide_array</key><array>"
+"""
+    wide_data = []
+    for i in range(100000):
+        wide_data.append([2.345,[1,2,3], "string", [llsd.uri("http://foo.bar.com")]])
+    return wide_data
+_wide_array_bench_data = build_wide_array_xml()
 
 def bench_stream(parse, stream):
     ret = parse(stream)
@@ -125,3 +162,35 @@ def test_format_notation(benchmark):
 
 def test_format_binary(benchmark):
     benchmark(llsd.format_binary, _bench_data)
+
+def test_format_xml_deep(benchmark):
+    benchmark(llsd.format_xml, _deep_bench_data)
+
+def test_format_xml_wide(benchmark):
+    benchmark(llsd.format_xml, _wide_bench_data)
+
+def test_format_notation_deep(benchmark):
+    benchmark(llsd.format_notation, _deep_bench_data)
+
+def test_format_notation_wide(benchmark):
+    benchmark(llsd.format_notation, _wide_bench_data)
+
+def test_format_notation_wide_array(benchmark):
+    benchmark(llsd.format_notation, _wide_array_bench_data)
+
+def test_format_binary_deep(benchmark):
+    benchmark(llsd.format_binary, _deep_bench_data)
+
+def test_format_binary_wide(benchmark):
+    benchmark(llsd.format_binary, _wide_bench_data)
+
+def test_format_binary_wide_array(benchmark):
+    benchmark(llsd.format_binary, _wide_array_bench_data)
+
+def test_parse_xml_deep(benchmark):
+    deep_data = llsd.format_xml(_deep_bench_data)
+    benchmark(llsd.parse_xml, deep_data)
+
+def test_parse_binary_deep(benchmark):
+    deep_data = llsd.format_binary(_deep_bench_data)
+    benchmark(llsd.parse_binary, deep_data)

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -84,7 +84,7 @@ def binary_stream():
 def build_deep_xml():
     deep_data = {}
     curr_data = deep_data
-    for i in range(250):
+    for i in range(198):
         curr_data["curr_data"] = {}
         curr_data["integer"] = 7
         curr_data["string"] = "string"

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -16,7 +16,7 @@ import uuid
 import pytest
 
 import llsd
-from llsd.base import PY2, is_integer, is_string, is_unicode
+from llsd.base import PY2, is_integer, is_string, is_unicode, MAX_FORMAT_DEPTH, MAX_PARSE_DEPTH
 from llsd.serde_xml import remove_invalid_xml_bytes
 from tests.fuzz import LLSDFuzzer
 
@@ -533,7 +533,7 @@ class LLSDNotationUnitTest(unittest.TestCase):
         """
 
         test_map = {"foo":"bar", "depth":0}
-        max_depth = 199
+        max_depth = MAX_FORMAT_DEPTH - 1
         for depth in range(max_depth):
             test_map = {"foo":"bar", "depth":depth, "next":test_map}
 
@@ -990,7 +990,7 @@ class LLSDBinaryUnitTest(unittest.TestCase):
         """
 
         test_map = {"foo":"bar", "depth":0}
-        max_depth = 199
+        max_depth = MAX_FORMAT_DEPTH -1
         for depth in range(max_depth):
             test_map = {"foo":"bar", "depth":depth, "next":test_map}
 
@@ -1525,7 +1525,7 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
         """
 
         test_map = {"foo":"bar", "depth":0}
-        max_depth = 199
+        max_depth = MAX_FORMAT_DEPTH - 1
         for depth in range(max_depth):
             test_map = {"foo":"bar", "depth":depth, "next":test_map}
 

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -527,6 +527,26 @@ class LLSDNotationUnitTest(unittest.TestCase):
     def testParseNotationInvalidHex(self):
         self.assertRaises(llsd.LLSDParseError, self.llsd.parse, b"'\\xzz'")
 
+    def testDeepMap(self):
+        """
+        Test formatting of a deeply nested map
+        """
+
+        test_map = {"foo":"bar", "depth":0}
+        max_depth = 199
+        for depth in range(max_depth):
+            test_map = {"foo":"bar", "depth":depth, "next":test_map}
+
+        # this should not throw an exception.
+        test_notation_out = self.llsd.as_notation(test_map)
+
+        test_notation_parsed = self.llsd.parse(io.BytesIO(test_notation_out))
+        self.assertEqual(test_map, test_notation_parsed)
+
+        test_map = {"foo":"bar", "depth":depth, "next":test_map}
+        # this should throw an exception.
+        self.assertRaises(llsd.LLSDSerializationError, self.llsd.as_notation, test_map)
+
 
 class LLSDBinaryUnitTest(unittest.TestCase):
     """
@@ -964,6 +984,26 @@ class LLSDBinaryUnitTest(unittest.TestCase):
 
         self.assertEqual('\t\x07\x08\x0c\n\r\t\x0b\x0fp', llsd.parse(delimited_string))
 
+    def testDeepMap(self):
+        """
+        Test formatting of a deeply nested map
+        """
+
+        test_map = {"foo":"bar", "depth":0}
+        max_depth = 199
+        for depth in range(max_depth):
+            test_map = {"foo":"bar", "depth":depth, "next":test_map}
+
+        # this should not throw an exception.
+        test_binary_out = self.llsd.as_binary(test_map)
+
+        test_binary_parsed = self.llsd.parse(io.BytesIO(test_binary_out))
+        self.assertEqual(test_map, test_binary_parsed)
+
+        test_map = {"foo":"bar", "depth":depth, "next":test_map}
+        # this should throw an exception.
+        self.assertRaises(llsd.LLSDSerializationError, self.llsd.as_binary, test_map)
+
 
 
 class LLSDPythonXMLUnitTest(unittest.TestCase):
@@ -1345,20 +1385,6 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
                                   map_within_map_xml)
         self.assertXMLRoundtrip({}, blank_map_xml)
 
-    def testDeepMap(self):
-        """
-        Test that formatting a deeply nested map does not cause a RecursionError
-        """
-
-        test_map = {"foo":"bar", "depth":0, "next":None}
-        max_depth = 200
-        for depth in range(max_depth):
-            test_map = {"foo":"bar", "depth":depth, "next":test_map}
-
-        # this should not throw an exception.
-        test_xml = self.llsd.as_xml(test_map)
-
-
     def testBinary(self):
         """
         Test the parse and serialization of input type : binary.
@@ -1492,6 +1518,26 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
         format_xml_result = self.llsd.as_xml(python_object)
         self.assertEqual(result[result.find(b"?>") + 2: len(result)],
                          format_xml_result[format_xml_result.find(b"?>") + 2: len(format_xml_result)])
+
+    def testDeepMap(self):
+        """
+        Test formatting of a deeply nested map
+        """
+
+        test_map = {"foo":"bar", "depth":0}
+        max_depth = 199
+        for depth in range(max_depth):
+            test_map = {"foo":"bar", "depth":depth, "next":test_map}
+
+        # this should not throw an exception.
+        test_xml_out = self.llsd.as_xml(test_map)
+
+        test_xml_parsed = self.llsd.parse(io.BytesIO(test_xml_out))
+        self.assertEqual(test_map, test_xml_parsed)
+
+        test_map = {"foo":"bar", "depth":depth, "next":test_map}
+        # this should throw an exception.
+        self.assertRaises(llsd.LLSDSerializationError, self.llsd.as_xml, test_map)
 
     def testLLSDSerializationFailure(self):
         """


### PR DESCRIPTION
A number of small perf optimizations:
* use 'translate' to translate all xml characters at once instead of doing multiple string translation passes.
* construct strings inline using writelines instead of doing it through a function, in order to save function call cost.
Also, includes SL-19700 - limit of 200 on depth for formatting and parsing (all types)