### PR TITLE
Bump codecov-action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,14 @@ jobs:
     name: Test & Build
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.10']
+        python-version: ['3.7', '3.8', '3.10']
+        image-variant: ['']
+        include:
+          - python-version: '2.7'
+            image-variant: '-buster'
     runs-on: [ubuntu-latest]
     container:
-      image: "python:${{ matrix.python-version }}-buster"
+      image: "python:${{ matrix.python-version }}${{ matrix.image-variant }}"
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
@@ -44,7 +48,7 @@ jobs:
         run: python -m build
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: matrix.python-version == '3.10'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Switched all builds except for python 2.7 from a debian buster based host container to the default. This fixes a system incompatibility between the new codecov action and nearly-dead buster.