### PR TITLE
Update pre-commit hooks to avoid isort installation error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
     - id: check-ast
     - id: check-yaml
     - id: mixed-line-ending
     - id: trailing-whitespace
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.13.2
   hooks:
     - id: isort
       args: [--line-length=120]


### PR DESCRIPTION
Hi! When I try to run the configured pre-commit hooks, I get an error:

```text
~/Work/python-llsd $ git log --graph --oneline -1
*   acb55e3 (HEAD -> main, tag: v1.2.4, origin/main, origin/HEAD) Merge pull request #23 from secondlife/signal/fix-array-indent
|\

~/Work/python-llsd $ pre-commit run -a
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/natty/.cache/pre-commit/repoprmfbeac/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /Users/natty/.cache/pre-commit/repoprmfbeac
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
stderr:
      error: subprocess-exited-with-error

      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [17 lines of output]
          Traceback (most recent call last):
            File "/Users/natty/.cache/pre-commit/repoprmfbeac/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/Users/natty/.cache/pre-commit/repoprmfbeac/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/Users/natty/.cache/pre-commit/repoprmfbeac/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/5b/4fh6_f3n7v92473v7w0zx5400000gp/T/pip-build-env-9r_c1_7f/overlay/lib/python3.12/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/5b/4fh6_f3n7v92473v7w0zx5400000gp/T/pip-build-env-9r_c1_7f/overlay/lib/python3.12/site-packages/poetry/core/factory.py", line 60, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - data.extras.pipfile_deprecated_finder[2] must match pattern ^[a-zA-Z-_.0-9]+$

          [end of output]

      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed

    × Encountered error while generating package metadata.
    ╰─> See above for output.

    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /Users/natty/.cache/pre-commit/pre-commit.log

~/Work/python-llsd $
```

We've seen this in other repositories that have used isort before 5.12.0: since isort doesn't/can't lock the Poetry version used to install it, [they ran into an issue](https://github.com/PyCQA/isort/commit/0d219a6e0b49b7f84ef0702b2387d5e14299bb8e) where they had put a version stricture in the `pipfile_deprecated_finder` field, but as of poetry-core 1.5.0 only module names are allowed in that field.

Let's upgrade the pre-commit hooks to the latest released versions [with `pre-commit autoupdate`](https://pre-commit.com/#updating-hooks-automatically). This will upgrade isort to a version that can install & run with its currently available dependencies.
