### PR TITLE
Allow dependabot in CLA check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,18 @@ jobs:
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # fetch all history for setuptools_scm to be able to read tags
+
+      - name: Fix Debian Buster repositories (EOL)
+        if: matrix.image-variant == '-buster'
+        run: |
+          # Debian Buster reached EOL, switch to archive.debian.org
+          # Remove security repo entirely (not available in archive) and use main archive
+          sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list
+          sed -i '/security.debian.org/d' /etc/apt/sources.list
+          sed -i '/buster-updates/d' /etc/apt/sources.list
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -23,3 +23,4 @@ jobs:
           path-to-signatures: signatures.json
           remote-organization-name: secondlife
           remote-repository-name: cla-signatures
+          allowlist: dependabot[bot]


### PR DESCRIPTION
Add dependabot[bot] to the allowlist so PRs that include dependabot commits don't fail the CLA check.

Use debian buster archive for python 2.7 tests