### PR TITLE
Make the xml output better match files in the sim/viewer

### DIFF
--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -69,7 +69,7 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
     interface to this functionality.
     """
 
-    def __init__(self, indent_atom: bytes = b'', eol: bytes = b'', c_compat: bool = False, sort_maps: bool = False):
+    def __init__(self, indent_atom = b'', eol = b'', c_compat = False, sort_maps = False):
         "Construct a serializer."
         # Call the super class constructor so that we have the type map
         super(LLSDXMLFormatter, self).__init__()
@@ -99,7 +99,7 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
             if int(v) == v:
                 s = str(int(v))
             else:
-                s = f"{v:.25g}"
+                s = "%.25g" % v
         else:
             s = str(v)
         self.stream.writelines([b'<real>', s.encode('utf-8'),  b'</real>', self._eol])
@@ -195,7 +195,7 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
     This class is not necessarily suited for serializing very large objects.
     It sorts on dict (llsd map) keys alphabetically to ease human reading.
     """
-    def __init__(self, indent_atom: bytes = b'  ', eol: bytes = b'\n', c_compat: bool = False, sort_maps: bool = True):
+    def __init__(self, indent_atom = b'  ', eol = b'\n', c_compat = False, sort_maps = True):
         "Construct a pretty serializer."
         # Call the super class constructor so that we have the type map
         super(LLSDXMLPrettyFormatter, self).__init__(indent_atom = indent_atom, eol = eol, c_compat=c_compat, sort_maps = sort_maps)
@@ -208,16 +208,16 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
         if not v:
             self.stream.writelines([b'<array />', self._eol])
         else:
-            super()._ARRAY(v)
+            super(LLSDXMLPrettyFormatter, self)._ARRAY(v)
 
     def _STRING(self, v):
         if not v:
             self.stream.writelines([b'<string />', self._eol])
         else:
-            super()._STRING(v)
+            super(LLSDXMLPrettyFormatter, self)._STRING(v)
 
 
-def format_pretty_xml(something, indent: int = 4, c_compat: bool = False, sort_maps: bool = True):
+def format_pretty_xml(something, indent = 4, c_compat = False, sort_maps = True):
     """
     Serialize a python object as 'pretty' application/llsd+xml.
 
@@ -236,7 +236,7 @@ def format_pretty_xml(something, indent: int = 4, c_compat: bool = False, sort_m
     return LLSDXMLPrettyFormatter(indent_atom=b' '*indent, c_compat=c_compat, sort_maps=sort_maps).format(something)
 
 
-def write_pretty_xml(stream, something, indent: int = 4, c_compat: bool = False, sort_maps: bool = True):
+def write_pretty_xml(stream, something, indent = 4, c_compat = False, sort_maps = True):
     """
     Serialize to passed 'stream' the python object 'something' as 'pretty'
     application/llsd+xml.

--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -217,7 +217,7 @@ class LLSDXMLPrettyFormatter(LLSDXMLFormatter):
             super(LLSDXMLPrettyFormatter, self)._STRING(v)
 
 
-def format_pretty_xml(something, indent = 4, c_compat = False, sort_maps = True):
+def format_pretty_xml(something, indent = 2, c_compat = False, sort_maps = True):
     """
     Serialize a python object as 'pretty' application/llsd+xml.
 
@@ -236,7 +236,7 @@ def format_pretty_xml(something, indent = 4, c_compat = False, sort_maps = True)
     return LLSDXMLPrettyFormatter(indent_atom=b' '*indent, c_compat=c_compat, sort_maps=sort_maps).format(something)
 
 
-def write_pretty_xml(stream, something, indent = 4, c_compat = False, sort_maps = True):
+def write_pretty_xml(stream, something, indent = 2, c_compat = False, sort_maps = True):
     """
     Serialize to passed 'stream' the python object 'something' as 'pretty'
     application/llsd+xml.

--- a/tests/fixtures/viewer-autobuild.xml
+++ b/tests/fixtures/viewer-autobuild.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <llsd>
-<map>
+  <map>
     <key>installables</key>
     <map>
       <key>SDL</key>

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -1520,7 +1520,7 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
 
         self.assertEqual(output_xml.decode("utf8"), """<?xml version="1.0" ?>
 <llsd>
-<map>
+  <map>
     <key>id</key>
     <array>
       <string>string1</string>


### PR DESCRIPTION
I made 4 changes that generate smaller diffs when compared against `keywords_lsl_default.xml` in the viewer and viewer cache. I needed that in https://github.com/secondlife/lsl-definitions/pull/38 where I auto-generate those files

- Adds option `c-compat` to xml generation. 
  - before: `<boolean>true</boolean>`. after: `<boolean>1</boolean>`
  - before: `<real>10.0</real>`. after: `<real>10</real>`
  - before: `<real>0.1</real>`. after: `<real>0.1000000000000000055511151</real>`
- Adds option `sort_maps` that sorts all the keys of a map alphabetically
  - I ended up not using this
- When the pretty-printer is used, empty strings and arrays are now collapsed:
  - before: `<string></string>`. after: `<string />`
  - before: `<array></array>`. after: `<after />`
- The first tag after `<llsd>` is now indented correctly when pretty-printing

---

Part of a set of PR's improving the definitions and keywords files in lsl and slua:
- https://github.com/secondlife/lsl-definitions/pull/38
- https://github.com/secondlife/viewer/pull/5288
  - https://github.com/secondlife/viewer/pull/5301
- https://github.com/secondlife/sl-vscode-plugin/pull/57
- https://github.com/secondlife/python-llsd/pull/37