### PR TITLE
Properly indent the first tag after <llsd>

### DIFF
--- a/llsd/serde_xml.py
+++ b/llsd/serde_xml.py
@@ -162,6 +162,7 @@ class LLSDXMLFormatter(LLSDBaseFormatter):
         """
         self.stream.writelines([b'<?xml version="1.0" ?>', self._eol,
                                 b'<llsd>', self._eol])
+        self._indent()
         self._generate(something)
         self.stream.write(b'</llsd>' + self._eol)
 

--- a/tests/fixtures/viewer-autobuild.xml
+++ b/tests/fixtures/viewer-autobuild.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <llsd>
-<map>
+  <map>
     <key>installables</key>
     <map>
       <key>SDL</key>

--- a/tests/llsd_test.py
+++ b/tests/llsd_test.py
@@ -1520,7 +1520,7 @@ class LLSDPythonXMLUnitTest(unittest.TestCase):
 
         self.assertEqual(output_xml.decode("utf8"), """<?xml version="1.0" ?>
 <llsd>
-<map>
+  <map>
     <key>id</key>
     <array>
       <string>string1</string>


### PR DESCRIPTION
- An extract of Just the bugfix from #37 without all the new features